### PR TITLE
feat: playtest markers, MCP auto-update, version display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roxlit-installer",
   "private": true,
-  "version": "0.12.2",
+  "version": "0.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roxlit-installer",
   "private": true,
-  "version": "0.12.1",
+  "version": "0.12.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "roxlit"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roxlit"
-version = "0.12.1"
+version = "0.12.2"
 description = "Roxlit — launcher for AI-powered Roblox development"
 authors = ["Roxlit"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roxlit"
-version = "0.12.2"
+version = "0.13.0"
 description = "Roxlit — launcher for AI-powered Roblox development"
 authors = ["Roxlit"]
 edition = "2021"

--- a/src-tauri/src/bin/roxlit_mcp.rs
+++ b/src-tauri/src/bin/roxlit_mcp.rs
@@ -103,7 +103,7 @@ fn handle_tools_list(id: Value) -> Value {
                 },
                 {
                     "name": "get_logs",
-                    "description": "Read logs from a Roxlit session. Two sources: 'output' (default) for Studio game output (prints, warns, errors from user scripts — use this to debug the user's game), or 'system' for Roxlit infrastructure logs (rojo, mcp events). Use 'latest' for the current session or a session_id from list_sessions. Use tail to get only the last N lines.",
+                    "description": "Read logs from a Roxlit session. Two sources: 'output' (default) for Studio game output (prints, warns, errors from user scripts — use this to debug the user's game), or 'system' for Roxlit infrastructure logs (rojo, mcp events). Logs contain playtest markers (═══════ PLAYTEST #N START/END ═══════). Use the 'playtest' parameter to filter: 'latest' (default for output) returns only the most recent playtest, 'all' returns everything, or a number for a specific playtest.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
@@ -120,9 +120,13 @@ fn handle_tools_list(id: Value) -> Value {
                                 "type": "string",
                                 "description": "Session to read: 'latest' (default) or a session_id from list_sessions"
                             },
+                            "playtest": {
+                                "type": "string",
+                                "description": "Filter by playtest: 'latest' (default for output) returns only the most recent playtest, 'all' returns everything, or a number (e.g. '1', '2') for a specific playtest"
+                            },
                             "tail": {
                                 "type": "integer",
-                                "description": "Only return the last N lines (0 or omitted = all lines)"
+                                "description": "Only return the last N lines (0 or omitted = all lines). Applied after playtest filtering."
                             }
                         },
                         "required": ["project_path"]
@@ -280,6 +284,8 @@ fn tool_get_logs(id: Value, arguments: &Value) -> Value {
 
     let source = arguments["source"].as_str().unwrap_or("output");
     let session = arguments["session"].as_str().unwrap_or("latest");
+    let playtest_default = if source == "output" { "latest" } else { "all" };
+    let playtest = arguments["playtest"].as_str().unwrap_or(playtest_default);
     let tail = arguments["tail"].as_u64().unwrap_or(0) as usize;
 
     let logs_dir = std::path::Path::new(project_path)
@@ -308,12 +314,15 @@ fn tool_get_logs(id: Value, arguments: &Value) -> Value {
         }
     };
 
+    // Filter by playtest if requested
+    let filtered = filter_by_playtest(&content, playtest);
+
     let output = if tail > 0 {
-        let lines: Vec<&str> = content.lines().collect();
+        let lines: Vec<&str> = filtered.lines().collect();
         let start = lines.len().saturating_sub(tail);
         lines[start..].join("\n")
     } else {
-        content
+        filtered
     };
 
     // Truncate if extremely large to avoid flooding the AI context
@@ -395,6 +404,54 @@ fn tool_list_sessions(id: Value, arguments: &Value) -> Value {
             "isError": false
         }
     })
+}
+
+/// Filter log content by playtest markers.
+/// - "all": return everything as-is
+/// - "latest": return from the last PLAYTEST START marker to end of file
+/// - "N" (number): return lines between PLAYTEST #N START and PLAYTEST #N END
+fn filter_by_playtest(content: &str, playtest: &str) -> String {
+    if playtest == "all" {
+        return content.to_string();
+    }
+
+    let lines: Vec<&str> = content.lines().collect();
+    let marker_pattern = "═══════ PLAYTEST #";
+
+    if playtest == "latest" {
+        // Find the last START marker
+        let mut last_start = None;
+        for (i, line) in lines.iter().enumerate() {
+            if line.contains(marker_pattern) && line.contains("START") {
+                last_start = Some(i);
+            }
+        }
+        match last_start {
+            Some(start) => lines[start..].join("\n"),
+            None => content.to_string(), // No markers found, return all
+        }
+    } else if let Ok(n) = playtest.parse::<u32>() {
+        // Find PLAYTEST #N START and END
+        let start_marker = format!("PLAYTEST #{n} START");
+        let end_marker = format!("PLAYTEST #{n} END");
+        let mut start_idx = None;
+        let mut end_idx = None;
+        for (i, line) in lines.iter().enumerate() {
+            if line.contains(&start_marker) {
+                start_idx = Some(i);
+            }
+            if line.contains(&end_marker) {
+                end_idx = Some(i);
+            }
+        }
+        match (start_idx, end_idx) {
+            (Some(s), Some(e)) => lines[s..=e].join("\n"),
+            (Some(s), None) => lines[s..].join("\n"), // Still running
+            _ => format!("No playtest #{n} found in logs"),
+        }
+    } else {
+        content.to_string() // Unknown value, return all
+    }
 }
 
 /// Helper for MCP tool error responses.

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -581,9 +581,8 @@ async fn handle_connection(
     }
 
     if first_line.starts_with("POST /playtest-start") {
-        // Tell the output writer to rotate: close current file, rename, open fresh
-        let _ = output_tx.send(ROTATE_SENTINEL.to_string());
-        send_log(&system_tx, "roxlit", "Playtest started — rotating output.log");
+        // Legacy endpoint — markers now come through POST /log with level "marker"
+        send_log(&system_tx, "roxlit", "Playtest started");
         let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\nok";
         let _ = stream.write_all(response.as_bytes()).await;
         return;
@@ -747,6 +746,7 @@ fn process_log_batch(tx: &mpsc::UnboundedSender<String>, body: &str) {
         let level = entry["level"].as_str().unwrap_or("info");
 
         let formatted = match level {
+            "marker" => format!("{ts} ═══════ {message} ═══════\n"),
             "error" => format!("{ts} [ERROR] {message}\n"),
             "warn" => format!("{ts} [WARN] {message}\n"),
             _ => format!("{ts} {message}\n"),

--- a/src-tauri/src/commands/rojo.rs
+++ b/src-tauri/src/commands/rojo.rs
@@ -493,8 +493,8 @@ fn move_luau_tree(src: &std::path::Path, dest: &std::path::Path) {
     }
 }
 
-/// Download roxlit-mcp binary if it doesn't exist yet.
-/// This handles upgrades from versions that didn't include MCP.
+/// Download or update roxlit-mcp binary.
+/// Re-downloads when the launcher version changes (version tracked in .roxlit/bin/mcp.version).
 async fn ensure_mcp_binary() {
     let mcp_bin_name = if cfg!(target_os = "windows") {
         "roxlit-mcp.exe"
@@ -508,8 +508,17 @@ async fn ensure_mcp_binary() {
     };
 
     let mcp_path = bin_dir.join(mcp_bin_name);
+    let version_file = bin_dir.join("mcp.version");
+    let current_version = env!("CARGO_PKG_VERSION");
+
+    // Check if binary exists AND version matches
     if mcp_path.exists() {
-        return; // Already downloaded
+        if let Ok(stored) = tokio::fs::read_to_string(&version_file).await {
+            if stored.trim() == current_version {
+                return; // Up to date
+            }
+        }
+        // Version mismatch or no version file — re-download
     }
 
     // Determine download URL
@@ -525,6 +534,8 @@ async fn ensure_mcp_binary() {
         if response.status().is_success() {
             if let Ok(bytes) = response.bytes().await {
                 let _ = tokio::fs::write(&mcp_path, &bytes).await;
+                // Track which version this binary belongs to
+                let _ = tokio::fs::write(&version_file, current_version).await;
                 #[cfg(unix)]
                 {
                     use std::os::unix::fs::PermissionsExt;

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Roxlit",
-  "version": "0.12.2",
+  "version": "0.13.0",
   "identifier": "dev.roxlit.app",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Roxlit",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "identifier": "dev.roxlit.app",
   "build": {
     "frontendDist": "../dist",

--- a/src/components/launcher/Launcher.tsx
+++ b/src/components/launcher/Launcher.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { invoke } from "@tauri-apps/api/core";
+import { getVersion } from "@tauri-apps/api/app";
 import { LogTerminal } from "./LogTerminal";
 import { UpdateBanner } from "./UpdateBanner";
 import { SettingsPopover } from "./SettingsPopover";
@@ -116,8 +117,13 @@ export function Launcher({
 }: LauncherProps) {
   const [editorLoading, setEditorLoading] = useState(false);
   const [projectDropdownOpen, setProjectDropdownOpen] = useState(false);
+  const [appVersion, setAppVersion] = useState<string | null>(null);
   const projectDropdownRef = useRef<HTMLDivElement>(null);
   const hasMultipleProjects = allProjects.length > 1;
+
+  useEffect(() => {
+    getVersion().then(setAppVersion).catch(() => {});
+  }, []);
 
   // Close project dropdown on outside click
   useEffect(() => {
@@ -305,6 +311,9 @@ export function Launcher({
             onUpdateDelayChange={onUpdateDelayChange}
           />
         </div>
+        {appVersion && (
+          <span className="text-[11px] text-zinc-600">v{appVersion}</span>
+        )}
         <button
           onClick={() => openExternal("https://github.com/Roxlit/installer/discussions")}
           className="flex items-center gap-1.5 text-xs text-zinc-500 transition-colors hover:text-zinc-300"


### PR DESCRIPTION
## Summary
- **Playtest markers**: LogCapture inserts `═══════ PLAYTEST #N START/END ═══════` markers in output.log. `get_logs` MCP tool defaults to filtering latest playtest only, preventing AI from reading stale data.
- **MCP binary auto-update**: `ensure_mcp_binary()` now tracks version in `~/.roxlit/bin/mcp.version` and re-downloads when the launcher version changes. Fixes users stuck on old MCP binary missing get_logs/list_sessions.
- **Version display**: Shows app version (e.g. `v0.13.0`) in launcher bottom bar via Tauri API.

## Test plan
- [ ] Start Development, play in Studio, stop play → verify output.log has `═══════ PLAYTEST #1 START ═══════` and `═══════ PLAYTEST #1 END ═══════` markers
- [ ] Delete `~/.roxlit/bin/roxlit-mcp.exe`, Start Development → binary re-downloaded
- [ ] Update launcher version, Start Development → binary re-downloaded (version mismatch)
- [ ] Launcher bottom bar shows version between Settings and Feedback
- [ ] `get_logs` with default params returns only latest playtest logs
- [ ] `get_logs` with `playtest: "all"` returns full output.log

🤖 Generated with [Claude Code](https://claude.com/claude-code)