### PR TITLE
feat: auto-backups, backup fixes, log improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roxlit-installer",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.14.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "roxlit"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roxlit"
-version = "0.13.0"
+version = "0.14.0"
 description = "Roxlit — launcher for AI-powered Roblox development"
 authors = ["Roxlit"]
 edition = "2021"

--- a/src-tauri/src/bin/roxlit_mcp.rs
+++ b/src-tauri/src/bin/roxlit_mcp.rs
@@ -663,7 +663,10 @@ fn tool_backup_restore(id: Value, arguments: &Value) -> Value {
         Some(p) => p,
         None => return mcp_error_result(id, "'project_path' parameter is required"),
     };
-    let backup_id = match arguments["id"].as_str() {
+    let backup_id = match arguments["id"]
+        .as_str()
+        .or_else(|| arguments["backup_id"].as_str())
+    {
         Some(i) => i,
         None => return mcp_error_result(id, "'id' parameter is required"),
     };
@@ -733,7 +736,10 @@ fn tool_backup_diff(id: Value, arguments: &Value) -> Value {
         Some(p) => p,
         None => return mcp_error_result(id, "'project_path' parameter is required"),
     };
-    let backup_id = match arguments["id"].as_str() {
+    let backup_id = match arguments["id"]
+        .as_str()
+        .or_else(|| arguments["backup_id"].as_str())
+    {
         Some(i) => i,
         None => return mcp_error_result(id, "'id' parameter is required"),
     };

--- a/src-tauri/src/bin/roxlit_mcp.rs
+++ b/src-tauri/src/bin/roxlit_mcp.rs
@@ -683,8 +683,13 @@ fn tool_backup_restore(id: Value, arguments: &Value) -> Value {
 
     let stash_ref = format!("stash@{{{stash_index}}}");
 
+    // Skip auto-backup if restoring a pre-restore backup (undoing a restore)
+    // because the current state already exists as the backup we originally restored from
+    let is_undo_restore = is_pre_restore_backup(project_path, backup_id);
+
     // Auto-backup current state before restoring (so user can undo the restore)
     let mut auto_backup_msg = String::new();
+    if !is_undo_restore {
     let _ = run_git(project_path, &["add", "-A"]);
     if let Ok(sha) = run_git(project_path, &["stash", "create"]) {
         let sha = sha.trim().to_string();
@@ -716,6 +721,7 @@ fn tool_backup_restore(id: Value, arguments: &Value) -> Value {
         }
     }
     let _ = run_git(project_path, &["reset"]);
+    } // end if !is_undo_restore
 
     // Restore files from stash without dropping it
     if let Err(e) = run_git(project_path, &["checkout", &stash_ref, "--", "."]) {
@@ -822,6 +828,23 @@ fn ensure_git_repo(path: &str) -> Result<(), String> {
         .map_err(|e| format!("Failed to create initial commit: {e}"))?;
 
     Ok(())
+}
+
+/// Check if a backup ID corresponds to an auto pre-restore backup.
+fn is_pre_restore_backup(path: &str, backup_id: &str) -> bool {
+    let manifest_path = Path::new(path).join(".roxlit").join("backups.jsonl");
+    if let Ok(content) = std::fs::read_to_string(&manifest_path) {
+        for line in content.lines() {
+            if let Ok(entry) = serde_json::from_str::<Value>(line) {
+                if entry["id"].as_str() == Some(backup_id) {
+                    if let Some(name) = entry["name"].as_str() {
+                        return name.starts_with("pre-restore-");
+                    }
+                }
+            }
+        }
+    }
+    false
 }
 
 /// Find the stash index for a given backup ID by searching git stash list.

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -8,9 +8,17 @@ use std::process::Command;
 
 /// Run a git command in the given directory.
 pub fn run_git(path: &str, args: &[&str]) -> Result<String, String> {
-    let output = Command::new("git")
-        .args(args)
-        .current_dir(path)
+    let mut cmd = Command::new("git");
+    cmd.args(args).current_dir(path);
+
+    // Prevent console windows from flashing on Windows
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    }
+
+    let output = cmd
         .output()
         .map_err(|e| format!("Failed to run git: {e}"))?;
 
@@ -33,7 +41,14 @@ pub fn ensure_git_repo(path: &str) -> Result<(), String> {
         return Ok(());
     }
 
-    if Command::new("git").arg("--version").output().is_err() {
+    let mut version_cmd = Command::new("git");
+    version_cmd.arg("--version");
+    #[cfg(target_os = "windows")]
+    {
+        use std::os::windows::process::CommandExt;
+        version_cmd.creation_flags(0x08000000);
+    }
+    if version_cmd.output().is_err() {
         return Err(
             "Git is not installed. Backups require git. Download it from: https://git-scm.com"
                 .to_string(),

--- a/src-tauri/src/commands/backup.rs
+++ b/src-tauri/src/commands/backup.rs
@@ -1,0 +1,345 @@
+//! Backup system — creates git stash snapshots of project state.
+//! Used by both the MCP server (roxlit_mcp.rs) and auto-backup timer.
+
+use serde_json::{json, Value};
+use std::io::Write;
+use std::path::Path;
+use std::process::Command;
+
+/// Run a git command in the given directory.
+pub fn run_git(path: &str, args: &[&str]) -> Result<String, String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(path)
+        .output()
+        .map_err(|e| format!("Failed to run git: {e}"))?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        if stderr.trim().is_empty() {
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        } else {
+            Err(stderr)
+        }
+    }
+}
+
+/// Ensure the project directory is a git repository.
+pub fn ensure_git_repo(path: &str) -> Result<(), String> {
+    let git_dir = Path::new(path).join(".git");
+    if git_dir.exists() {
+        return Ok(());
+    }
+
+    if Command::new("git").arg("--version").output().is_err() {
+        return Err(
+            "Git is not installed. Backups require git. Download it from: https://git-scm.com"
+                .to_string(),
+        );
+    }
+
+    run_git(path, &["init"]).map_err(|e| format!("Failed to init git repo: {e}"))?;
+    run_git(path, &["add", "-A"]).map_err(|e| format!("Failed to stage files: {e}"))?;
+    run_git(path, &["commit", "-m", "roxlit: initial commit for backups"])
+        .map_err(|e| format!("Failed to create initial commit: {e}"))?;
+
+    Ok(())
+}
+
+/// Get the next backup ID (bk-001, bk-002, etc.) from the manifest.
+pub fn next_backup_id(path: &str) -> String {
+    let manifest_path = Path::new(path).join(".roxlit").join("backups.jsonl");
+
+    let mut max_num: u32 = 0;
+    if let Ok(content) = std::fs::read_to_string(&manifest_path) {
+        for line in content.lines() {
+            if let Ok(entry) = serde_json::from_str::<Value>(line) {
+                if let Some(id) = entry["id"].as_str() {
+                    if let Some(num_str) = id.strip_prefix("bk-") {
+                        if let Ok(n) = num_str.parse::<u32>() {
+                            max_num = max_num.max(n);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    format!("bk-{:03}", max_num + 1)
+}
+
+/// Get current timestamp as ISO 8601 string (cross-platform).
+pub fn now_timestamp() -> String {
+    let duration = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = duration.as_secs();
+
+    let days = secs / 86400;
+    let time_secs = secs % 86400;
+    let hours = time_secs / 3600;
+    let minutes = (time_secs % 3600) / 60;
+    let seconds = time_secs % 60;
+
+    let mut y = 1970i64;
+    let mut remaining = days as i64;
+    loop {
+        let days_in_year = if y % 4 == 0 && (y % 100 != 0 || y % 400 == 0) {
+            366
+        } else {
+            365
+        };
+        if remaining < days_in_year {
+            break;
+        }
+        remaining -= days_in_year;
+        y += 1;
+    }
+    let leap = y % 4 == 0 && (y % 100 != 0 || y % 400 == 0);
+    let month_days = [
+        31,
+        if leap { 29 } else { 28 },
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    ];
+    let mut m = 0;
+    for md in &month_days {
+        if remaining < *md {
+            break;
+        }
+        remaining -= md;
+        m += 1;
+    }
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        y,
+        m + 1,
+        remaining + 1,
+        hours,
+        minutes,
+        seconds
+    )
+}
+
+/// Find the stash index for a given backup ID.
+pub fn find_stash_index(path: &str, backup_id: &str) -> Option<usize> {
+    let stash_list = run_git(path, &["stash", "list"]).ok()?;
+    let pattern = format!("roxlit:{backup_id}:");
+
+    for line in stash_list.lines() {
+        if line.contains(&pattern) {
+            let start = line.find('{')? + 1;
+            let end = line.find('}')?;
+            return line[start..end].parse().ok();
+        }
+    }
+    None
+}
+
+/// Check if a backup ID is a pre-restore backup.
+pub fn is_pre_restore_backup(path: &str, backup_id: &str) -> bool {
+    let manifest_path = Path::new(path).join(".roxlit").join("backups.jsonl");
+    if let Ok(content) = std::fs::read_to_string(&manifest_path) {
+        for line in content.lines() {
+            if let Ok(entry) = serde_json::from_str::<Value>(line) {
+                if entry["id"].as_str() == Some(backup_id) {
+                    if let Some(name) = entry["name"].as_str() {
+                        return name.starts_with("pre-restore-");
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Create a backup. Returns (backup_id, message) on success.
+pub fn create_backup(path: &str, name: &str) -> Result<(String, String), String> {
+    ensure_git_repo(path)?;
+
+    // Stage everything so stash captures untracked files
+    run_git(path, &["add", "-A"]).map_err(|e| format!("Failed to stage files: {e}"))?;
+
+    let sha = run_git(path, &["stash", "create"])
+        .map_err(|e| format!("Failed to create stash: {e}"))?
+        .trim()
+        .to_string();
+
+    // Reset index
+    let _ = run_git(path, &["reset"]);
+
+    if sha.is_empty() {
+        return Err("Nothing to backup — no changes detected since last commit.".to_string());
+    }
+
+    let backup_id = next_backup_id(path);
+    let label = if name.is_empty() {
+        backup_id.clone()
+    } else {
+        name.to_string()
+    };
+    let stash_msg = format!("roxlit:{backup_id}:{label}");
+
+    run_git(path, &["stash", "store", "-m", &stash_msg, &sha])
+        .map_err(|e| format!("Failed to store stash: {e}"))?;
+
+    // Write to manifest
+    let timestamp = now_timestamp();
+    let manifest_dir = Path::new(path).join(".roxlit");
+    let _ = std::fs::create_dir_all(&manifest_dir);
+    let manifest_path = manifest_dir.join("backups.jsonl");
+
+    // Get list of changed files for metadata
+    let changed_files = run_git(path, &["stash", "show", "--name-only", &sha])
+        .unwrap_or_default()
+        .lines()
+        .map(|l| l.to_string())
+        .collect::<Vec<_>>();
+
+    let entry = json!({
+        "id": backup_id,
+        "name": if name.is_empty() { None::<&str> } else { Some(name) },
+        "timestamp": timestamp,
+        "stash_sha": sha,
+        "auto": name.starts_with("auto-"),
+        "files_changed": changed_files,
+    });
+
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&manifest_path)
+    {
+        let _ = writeln!(f, "{}", serde_json::to_string(&entry).unwrap_or_default());
+    }
+
+    let display_name = if name.is_empty() {
+        backup_id.clone()
+    } else {
+        format!("{backup_id} ({name})")
+    };
+
+    Ok((
+        backup_id,
+        format!("Backup created: {display_name}\nTimestamp: {timestamp}"),
+    ))
+}
+
+/// Get total size of all roxlit stashes in bytes.
+pub fn total_stash_size(path: &str) -> u64 {
+    let manifest_path = Path::new(path).join(".roxlit").join("backups.jsonl");
+    let content = match std::fs::read_to_string(&manifest_path) {
+        Ok(c) => c,
+        Err(_) => return 0,
+    };
+
+    let mut total: u64 = 0;
+    for line in content.lines() {
+        if let Ok(entry) = serde_json::from_str::<Value>(line) {
+            if let Some(sha) = entry["stash_sha"].as_str() {
+                // Get object size from git
+                if let Ok(size_str) = run_git(path, &["cat-file", "-s", sha]) {
+                    if let Ok(size) = size_str.trim().parse::<u64>() {
+                        total += size;
+                    }
+                }
+            }
+        }
+    }
+    total
+}
+
+/// Clean up old auto-backups if total size exceeds the limit.
+/// Removes oldest auto-backups first, keeps manual backups.
+pub fn cleanup_by_size(path: &str, max_bytes: u64) {
+    let manifest_path = Path::new(path).join(".roxlit").join("backups.jsonl");
+    let content = match std::fs::read_to_string(&manifest_path) {
+        Ok(c) => c,
+        Err(_) => return,
+    };
+
+    let entries: Vec<Value> = content
+        .lines()
+        .filter_map(|l| serde_json::from_str(l).ok())
+        .collect();
+
+    if entries.is_empty() {
+        return;
+    }
+
+    // Calculate current total size
+    let current_size = total_stash_size(path);
+    if current_size <= max_bytes {
+        return;
+    }
+
+    // Find auto-backups sorted by timestamp (oldest first)
+    let mut auto_indices: Vec<usize> = entries
+        .iter()
+        .enumerate()
+        .filter(|(_, e)| e["auto"].as_bool().unwrap_or(false))
+        .map(|(i, _)| i)
+        .collect();
+
+    // Sort by timestamp ascending (oldest first)
+    auto_indices.sort_by(|a, b| {
+        let ts_a = entries[*a]["timestamp"].as_str().unwrap_or("");
+        let ts_b = entries[*b]["timestamp"].as_str().unwrap_or("");
+        ts_a.cmp(ts_b)
+    });
+
+    // Remove oldest auto-backups until under limit
+    let mut removed = Vec::new();
+    let mut estimated_size = current_size;
+    for idx in &auto_indices {
+        if estimated_size <= max_bytes {
+            break;
+        }
+        let entry = &entries[*idx];
+        if let Some(sha) = entry["stash_sha"].as_str() {
+            if let Ok(size_str) = run_git(path, &["cat-file", "-s", sha]) {
+                if let Ok(size) = size_str.trim().parse::<u64>() {
+                    estimated_size = estimated_size.saturating_sub(size);
+                }
+            }
+            // Drop the stash from git
+            if let Some(backup_id) = entry["id"].as_str() {
+                if let Some(stash_idx) = find_stash_index(path, backup_id) {
+                    let stash_ref = format!("stash@{{{stash_idx}}}");
+                    let _ = run_git(path, &["stash", "drop", &stash_ref]);
+                }
+            }
+        }
+        removed.push(*idx);
+    }
+
+    if removed.is_empty() {
+        return;
+    }
+
+    // Rewrite manifest without removed entries
+    let removed_set: std::collections::HashSet<usize> = removed.into_iter().collect();
+    let remaining: Vec<&Value> = entries
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| !removed_set.contains(i))
+        .map(|(_, e)| e)
+        .collect();
+
+    if let Ok(mut f) = std::fs::File::create(&manifest_path) {
+        for entry in remaining {
+            let _ = writeln!(f, "{}", serde_json::to_string(entry).unwrap_or_default());
+        }
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -1,3 +1,4 @@
+pub mod backup;
 pub mod config;
 pub mod detect;
 pub mod install;

--- a/src-tauri/src/commands/rojo.rs
+++ b/src-tauri/src/commands/rojo.rs
@@ -25,6 +25,7 @@ pub enum RojoEvent {
 pub struct RojoProcess {
     pub child: Arc<Mutex<Option<tokio::process::Child>>>,
     pub abort_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
+    pub backup_handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
 }
 
 impl Default for RojoProcess {
@@ -32,6 +33,7 @@ impl Default for RojoProcess {
         Self {
             child: Arc::new(Mutex::new(None)),
             abort_handle: Arc::new(Mutex::new(None)),
+            backup_handle: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -48,6 +50,12 @@ impl RojoProcess {
         }
         // Abort the reader task
         if let Ok(mut guard) = self.abort_handle.try_lock() {
+            if let Some(handle) = guard.take() {
+                handle.abort();
+            }
+        }
+        // Abort the auto-backup timer
+        if let Ok(mut guard) = self.backup_handle.try_lock() {
             if let Some(handle) = guard.take() {
                 handle.abort();
             }
@@ -333,6 +341,40 @@ pub async fn start_rojo(
         *guard = Some(reader_handle);
     }
 
+    // Start auto-backup timer (every 10 minutes)
+    let backup_project_path = project_path.clone();
+    let backup_handle = tokio::spawn(async move {
+        use crate::commands::backup;
+
+        // Wait 2 minutes before first backup (let user start working)
+        tokio::time::sleep(std::time::Duration::from_secs(120)).await;
+
+        let interval = std::time::Duration::from_secs(600); // 10 minutes
+        let max_backup_bytes: u64 = 100 * 1024 * 1024; // 100 MB default limit
+
+        loop {
+            // Create auto-backup (blocking git ops in spawn_blocking)
+            let path = backup_project_path.clone();
+            let _ = tokio::task::spawn_blocking(move || {
+                let name = format!("auto-{}", backup::now_timestamp());
+                match backup::create_backup(&path, &name) {
+                    Ok(_) => {
+                        // Cleanup old auto-backups if over size limit
+                        backup::cleanup_by_size(&path, max_backup_bytes);
+                    }
+                    Err(_) => {} // No changes or git not available — skip silently
+                }
+            })
+            .await;
+
+            tokio::time::sleep(interval).await;
+        }
+    });
+    {
+        let mut guard = state.backup_handle.lock().await;
+        *guard = Some(backup_handle);
+    }
+
     Ok(())
 }
 
@@ -375,6 +417,14 @@ pub async fn stop_rojo(
     // Abort the reader task
     {
         let mut guard = state.abort_handle.lock().await;
+        if let Some(handle) = guard.take() {
+            handle.abort();
+        }
+    }
+
+    // Stop auto-backup timer
+    {
+        let mut guard = state.backup_handle.lock().await;
         if let Some(handle) = guard.take() {
             handle.abort();
         }

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -209,6 +209,16 @@ MCP tools connect to Roblox Studio via the Roxlit plugin. Use them ONLY for:
 
 **Rule 6 — When in doubt, backup.** If you're not sure whether something will break, create a backup. The cost is zero. The cost of NOT backing up is starting over from scratch.
 
+### Auto-Backups
+
+Roxlit automatically creates backups every 10 minutes while "Start Development" is active. These are named `auto-{timestamp}` and appear in `backup_list` alongside your manual backups. Use them to:
+
+- **Recover from mistakes** — if the user says "it was working 20 minutes ago", check `backup_list` for the nearest auto-backup and restore it.
+- **Compare states** — use `backup_diff` with an auto-backup ID to see what changed in the last 10-20 minutes.
+- **Don't rely only on auto-backups** — they happen every 10min, so you can lose up to 10min of work. Still create manual backups before risky changes (Rules 1-3 above).
+
+Auto-backups are cleaned up automatically when total backup storage exceeds 100MB (oldest auto-backups removed first, manual backups are never auto-deleted).
+
 ### MCP Connection Issues
 
 If `run_code` or other MCP tools fail with connection errors, tell the user:

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -470,6 +470,7 @@ src/                                ← All game code and instances (synced by R
 - Require modules relatively: `require(script.Parent.ModuleName)`
 - Prefer `task.wait()` over `wait()`, `task.spawn()` over `spawn()`
 - Add `--!strict` at the top of every file
+- In `string.gsub()` replacements, `%` is a special character. Escape it as `%%` or use a function replacement: `gsub(pattern, function() return str end)`
 
 ## Instance Organization
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Roxlit",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "identifier": "dev.roxlit.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

### Auto-backups
- Automatic backups every 10 minutes while "Start Development" is active
- Shared backup module (`commands/backup.rs`) with git stash logic
- Cleanup by total size (100MB limit) — removes oldest auto-backups, keeps manual
- Each backup includes `files_changed` metadata for searchability
- Hidden console windows on Windows (`CREATE_NO_WINDOW`)

### Backup fixes
- Accept both `id` and `backup_id` parameter names (AI sends either)
- Skip redundant pre-restore backup when undoing a restore
- `gsub()` escape warning added to Luau coding standards

### Log fixes
- Truncate individual lines at 500 chars (Studio produces huge lines)
- Cap total `get_logs` output at 15KB (was 100KB, caused token overflow)
- Accept `tail` as string or number (AI sends `"50"` not `50`)
- Cross-platform timestamps using `SystemTime` (was `date -u`, failed on Windows)

### AI context updates
- Document all backup + log MCP tools
- Mandatory backup discipline rules
- Auto-backup awareness (AI knows they exist and can restore them)
- `gsub` % escape warning

### CI
- Build and upload `roxlit-mcp.exe` as separate artifact

## Test plan

- [x] Start development, wait 2+ minutes, check `backup_list` for auto-backup
- [x] Restore a backup, verify no console windows flash
- [x] Call `get_logs` with large output, verify truncation works
- [x] Verify AI context regenerates with backup documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)