### PR TITLE
feat: real-time telemetry system (v0.16.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "roxlit-installer",
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3279,7 +3279,7 @@ dependencies = [
 
 [[package]]
 name = "roxlit"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "anyhow",
  "dirs",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roxlit"
-version = "0.15.0"
+version = "0.16.0"
 description = "Roxlit — launcher for AI-powered Roblox development"
 authors = ["Roxlit"]
 edition = "2021"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "roxlit"
-version = "0.14.0"
+version = "0.15.0"
 description = "Roxlit — launcher for AI-powered Roblox development"
 authors = ["Roxlit"]
 edition = "2021"

--- a/src-tauri/src/bin/roxlit_mcp.rs
+++ b/src-tauri/src/bin/roxlit_mcp.rs
@@ -870,13 +870,17 @@ fn tool_telemetry_track(id: Value, arguments: &Value) -> Value {
         None => return mcp_error_result(id, "'properties' parameter is required"),
     };
 
-    // Use run_code to set the attribute on the instance
+    // Use run_code to register the instance with the telemetry module
     let code = format!(
         r#"
 local inst = {}
 if inst then
-    inst:SetAttribute("_roxlit_track", "{}")
-    print("[Telemetry] Tracking " .. inst:GetFullName() .. ": {}")
+    if _G._roxlit_telemetry then
+        _G._roxlit_telemetry:track(inst, "{}")
+        print("[Telemetry] Tracking " .. inst:GetFullName() .. ": {}")
+    else
+        warn("[Telemetry] Telemetry module not running. Is the Roxlit plugin loaded?")
+    end
 else
     warn("[Telemetry] Instance not found: {}")
 end
@@ -899,8 +903,12 @@ fn tool_telemetry_stop(id: Value, arguments: &Value) -> Value {
         r#"
 local inst = {}
 if inst then
-    inst:SetAttribute("_roxlit_track", nil)
-    print("[Telemetry] Stopped tracking " .. inst:GetFullName())
+    if _G._roxlit_telemetry then
+        _G._roxlit_telemetry:untrack(inst)
+        print("[Telemetry] Stopped tracking " .. inst:GetFullName())
+    else
+        warn("[Telemetry] Telemetry module not running")
+    end
 else
     warn("[Telemetry] Instance not found: {}")
 end

--- a/src-tauri/src/bin/roxlit_mcp.rs
+++ b/src-tauri/src/bin/roxlit_mcp.rs
@@ -215,6 +215,74 @@ fn handle_tools_list(id: Value) -> Value {
                         },
                         "required": ["project_path", "id"]
                     }
+                },
+                {
+                    "name": "telemetry_track",
+                    "description": "Start tracking properties of an instance in Roblox Studio. Sets the _roxlit_track attribute via run_code. The Roxlit plugin will automatically sample the specified properties and log changes to telemetry.log. Use this to observe physics behavior (position, velocity, rotation) without adding Debug.print() to scripts.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "instance_path": {
+                                "type": "string",
+                                "description": "Dot-separated path to the instance (e.g. 'Workspace.motorcycle_1_V2', 'Workspace.Player.HumanoidRootPart')"
+                            },
+                            "properties": {
+                                "type": "string",
+                                "description": "Comma-separated property names to track (e.g. 'CFrame,AssemblyLinearVelocity,AssemblyAngularVelocity')"
+                            }
+                        },
+                        "required": ["instance_path", "properties"]
+                    }
+                },
+                {
+                    "name": "telemetry_stop",
+                    "description": "Stop tracking an instance. Removes the _roxlit_track attribute.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "instance_path": {
+                                "type": "string",
+                                "description": "Dot-separated path to the instance to stop tracking"
+                            }
+                        },
+                        "required": ["instance_path"]
+                    }
+                },
+                {
+                    "name": "telemetry_get",
+                    "description": "Read telemetry data from the current session. Returns tracked property changes over time. Use 'tail' to limit output. Use 'instance' to filter by instance name. Use 'only_changes' to skip repeated values.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "project_path": {
+                                "type": "string",
+                                "description": "Absolute path to the project directory"
+                            },
+                            "instance": {
+                                "type": "string",
+                                "description": "Filter by instance name (e.g. 'motorcycle_1_V2'). Omit for all instances."
+                            },
+                            "tail": {
+                                "type": "integer",
+                                "description": "Only return the last N lines (0 = all)"
+                            }
+                        },
+                        "required": ["project_path"]
+                    }
+                },
+                {
+                    "name": "telemetry_clear",
+                    "description": "Clear all telemetry data for the current session. Use when starting a new debugging investigation.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "project_path": {
+                                "type": "string",
+                                "description": "Absolute path to the project directory"
+                            }
+                        },
+                        "required": ["project_path"]
+                    }
                 }
             ]
         }
@@ -233,6 +301,10 @@ fn handle_tools_call(id: Value, params: &Value) -> Value {
         "backup_list" => tool_backup_list(id, &arguments),
         "backup_restore" => tool_backup_restore(id, &arguments),
         "backup_diff" => tool_backup_diff(id, &arguments),
+        "telemetry_track" => tool_telemetry_track(id, &arguments),
+        "telemetry_stop" => tool_telemetry_stop(id, &arguments),
+        "telemetry_get" => tool_telemetry_get(id, &arguments),
+        "telemetry_clear" => tool_telemetry_clear(id, &arguments),
         _ => json!({
             "jsonrpc": "2.0",
             "id": id,
@@ -784,6 +856,143 @@ fn tool_backup_diff(id: Value, arguments: &Value) -> Value {
     };
 
     mcp_result(id, &output)
+}
+
+// ─── Telemetry tools ────────────────────────────────────────────────────────
+
+fn tool_telemetry_track(id: Value, arguments: &Value) -> Value {
+    let instance_path = match arguments["instance_path"].as_str() {
+        Some(p) => p,
+        None => return mcp_error_result(id, "'instance_path' parameter is required"),
+    };
+    let properties = match arguments["properties"].as_str() {
+        Some(p) => p,
+        None => return mcp_error_result(id, "'properties' parameter is required"),
+    };
+
+    // Use run_code to set the attribute on the instance
+    let code = format!(
+        r#"
+local inst = {}
+if inst then
+    inst:SetAttribute("_roxlit_track", "{}")
+    print("[Telemetry] Tracking " .. inst:GetFullName() .. ": {}")
+else
+    warn("[Telemetry] Instance not found: {}")
+end
+"#,
+        instance_path, properties, properties, instance_path
+    );
+
+    // Forward to run_code
+    let run_args = json!({ "code": code });
+    tool_run_code(id, &run_args)
+}
+
+fn tool_telemetry_stop(id: Value, arguments: &Value) -> Value {
+    let instance_path = match arguments["instance_path"].as_str() {
+        Some(p) => p,
+        None => return mcp_error_result(id, "'instance_path' parameter is required"),
+    };
+
+    let code = format!(
+        r#"
+local inst = {}
+if inst then
+    inst:SetAttribute("_roxlit_track", nil)
+    print("[Telemetry] Stopped tracking " .. inst:GetFullName())
+else
+    warn("[Telemetry] Instance not found: {}")
+end
+"#,
+        instance_path, instance_path
+    );
+
+    let run_args = json!({ "code": code });
+    tool_run_code(id, &run_args)
+}
+
+fn tool_telemetry_get(id: Value, arguments: &Value) -> Value {
+    let project_path = match arguments["project_path"].as_str() {
+        Some(p) => p,
+        None => return mcp_error_result(id, "'project_path' parameter is required"),
+    };
+
+    let instance_filter = arguments["instance"].as_str().unwrap_or("");
+    let tail = arguments["tail"]
+        .as_u64()
+        .or_else(|| arguments["tail"].as_str().and_then(|s| s.parse().ok()))
+        .unwrap_or(0) as usize;
+
+    let telemetry_file = std::path::Path::new(project_path)
+        .join(".roxlit")
+        .join("logs")
+        .join("telemetry.log");
+
+    if !telemetry_file.exists() {
+        return mcp_result(id, "No telemetry data yet. Use telemetry_track to start tracking an instance, then playtest.");
+    }
+
+    let content = match std::fs::read_to_string(&telemetry_file) {
+        Ok(c) => c,
+        Err(e) => return mcp_error_result(id, &format!("Error reading telemetry: {e}")),
+    };
+
+    // Filter by instance name if specified
+    let filtered: Vec<&str> = if instance_filter.is_empty() {
+        content.lines().collect()
+    } else {
+        content
+            .lines()
+            .filter(|line| line.contains(instance_filter))
+            .collect()
+    };
+
+    // Apply tail
+    let lines = if tail > 0 && filtered.len() > tail {
+        &filtered[filtered.len() - tail..]
+    } else {
+        &filtered[..]
+    };
+
+    let output = lines.join("\n");
+
+    if output.is_empty() {
+        return mcp_result(
+            id,
+            &format!("No telemetry data{}", if !instance_filter.is_empty() { format!(" for '{instance_filter}'") } else { String::new() }),
+        );
+    }
+
+    // Truncate if too large
+    let output = if output.len() > 15_000 {
+        format!(
+            "[...truncated, showing last ~15KB...]\n{}",
+            &output[output.len() - 15_000..]
+        )
+    } else {
+        output
+    };
+
+    mcp_result(id, &output)
+}
+
+fn tool_telemetry_clear(id: Value, arguments: &Value) -> Value {
+    let project_path = match arguments["project_path"].as_str() {
+        Some(p) => p,
+        None => return mcp_error_result(id, "'project_path' parameter is required"),
+    };
+
+    let telemetry_file = std::path::Path::new(project_path)
+        .join(".roxlit")
+        .join("logs")
+        .join("telemetry.log");
+
+    if telemetry_file.exists() {
+        let _ = std::fs::write(&telemetry_file, "");
+    }
+
+    mcp_result(id, "Telemetry data cleared.")
 }
 
 // ─── Git helpers ────────────────────────────────────────────────────────────

--- a/src-tauri/src/bin/roxlit_mcp.rs
+++ b/src-tauri/src/bin/roxlit_mcp.rs
@@ -218,17 +218,21 @@ fn handle_tools_list(id: Value) -> Value {
                 },
                 {
                     "name": "telemetry_track",
-                    "description": "Start tracking properties of an instance in Roblox Studio. Sets the _roxlit_track attribute via run_code. The Roxlit plugin will automatically sample the specified properties and log changes to telemetry.log. Use this to observe physics behavior (position, velocity, rotation) without adding Debug.print() to scripts.",
+                    "description": "Register an instance for real-time property tracking. The instance does NOT need to exist yet — tracking activates automatically when the instance appears (e.g. during playtest). Names with spaces are supported. Use 'group' to organize trackers for batch enable/disable.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
                             "instance_path": {
                                 "type": "string",
-                                "description": "Dot-separated path to the instance (e.g. 'Workspace.motorcycle_1_V2', 'Workspace.Player.HumanoidRootPart')"
+                                "description": "Dot-separated path to the instance (e.g. 'Workspace.motorcycle_1_V2 Motorcycle.DriveSeat', 'Workspace.Player.HumanoidRootPart'). Names with spaces are supported."
                             },
                             "properties": {
                                 "type": "string",
                                 "description": "Comma-separated property names to track (e.g. 'CFrame,AssemblyLinearVelocity,AssemblyAngularVelocity')"
+                            },
+                            "group": {
+                                "type": "string",
+                                "description": "Optional group name for batch enable/disable (e.g. 'moto-wheels', 'player')"
                             }
                         },
                         "required": ["instance_path", "properties"]
@@ -236,16 +240,37 @@ fn handle_tools_list(id: Value) -> Value {
                 },
                 {
                     "name": "telemetry_stop",
-                    "description": "Stop tracking an instance. Removes the _roxlit_track attribute.",
+                    "description": "Stop tracking. Pass 'instance_path' to stop a specific tracker, or 'group' to stop all trackers in a group.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
                             "instance_path": {
                                 "type": "string",
-                                "description": "Dot-separated path to the instance to stop tracking"
+                                "description": "Path of the instance to stop tracking"
+                            },
+                            "group": {
+                                "type": "string",
+                                "description": "Stop all trackers in this group"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "telemetry_toggle",
+                    "description": "Enable or disable a telemetry group without removing it. Useful to temporarily pause noisy trackers.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "group": {
+                                "type": "string",
+                                "description": "Group name to enable/disable"
+                            },
+                            "enabled": {
+                                "type": "boolean",
+                                "description": "true to enable, false to disable"
                             }
                         },
-                        "required": ["instance_path"]
+                        "required": ["group", "enabled"]
                     }
                 },
                 {
@@ -303,6 +328,7 @@ fn handle_tools_call(id: Value, params: &Value) -> Value {
         "backup_diff" => tool_backup_diff(id, &arguments),
         "telemetry_track" => tool_telemetry_track(id, &arguments),
         "telemetry_stop" => tool_telemetry_stop(id, &arguments),
+        "telemetry_toggle" => tool_telemetry_toggle(id, &arguments),
         "telemetry_get" => tool_telemetry_get(id, &arguments),
         "telemetry_clear" => tool_telemetry_clear(id, &arguments),
         _ => json!({
@@ -860,6 +886,27 @@ fn tool_backup_diff(id: Value, arguments: &Value) -> Value {
 
 // ─── Telemetry tools ────────────────────────────────────────────────────────
 
+/// POST JSON to a launcher endpoint. Returns Ok(body) or Err(message).
+fn http_post_json(url: &str, body: &str) -> Result<String, String> {
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(5))
+        .build()
+        .map_err(|e| format!("HTTP client error: {e}"))?;
+
+    let resp = client
+        .post(url)
+        .header("Content-Type", "application/json")
+        .body(body.to_string())
+        .send()
+        .map_err(|e| format!("Connection failed: {e}"))?;
+
+    if resp.status().is_success() {
+        Ok(resp.text().unwrap_or_default())
+    } else {
+        Err(format!("HTTP {}", resp.status()))
+    }
+}
+
 fn tool_telemetry_track(id: Value, arguments: &Value) -> Value {
     let instance_path = match arguments["instance_path"].as_str() {
         Some(p) => p,
@@ -869,55 +916,65 @@ fn tool_telemetry_track(id: Value, arguments: &Value) -> Value {
         Some(p) => p,
         None => return mcp_error_result(id, "'properties' parameter is required"),
     };
+    let group = arguments["group"].as_str().unwrap_or("default");
 
-    // Use run_code to register the instance with the telemetry module
-    let code = format!(
-        r#"
-local inst = {}
-if inst then
-    if _G._roxlit_telemetry then
-        _G._roxlit_telemetry:track(inst, "{}")
-        print("[Telemetry] Tracking " .. inst:GetFullName() .. ": {}")
-    else
-        warn("[Telemetry] Telemetry module not running. Is the Roxlit plugin loaded?")
-    end
-else
-    warn("[Telemetry] Instance not found: {}")
-end
-"#,
-        instance_path, properties, properties, instance_path
-    );
+    // POST to launcher — tracker is stored in memory, plugin polls for it
+    let body = json!({
+        "path": instance_path,
+        "properties": properties,
+        "group": group,
+    });
 
-    // Forward to run_code
-    let run_args = json!({ "code": code });
-    tool_run_code(id, &run_args)
+    let url = format!("{LAUNCHER_URL}/telemetry/track");
+    match http_post_json(&url, &body.to_string()) {
+        Ok(_) => mcp_result(id, &format!(
+            "Tracking registered: {} [{}] (group: {})\nThe plugin will start sampling when the instance exists (e.g. during playtest).",
+            instance_path, properties, group
+        )),
+        Err(e) => mcp_error_result(id, &format!("Failed to register tracker: {e}. Is the Roxlit launcher running?")),
+    }
 }
 
 fn tool_telemetry_stop(id: Value, arguments: &Value) -> Value {
-    let instance_path = match arguments["instance_path"].as_str() {
-        Some(p) => p,
-        None => return mcp_error_result(id, "'instance_path' parameter is required"),
+    let instance_path = arguments["instance_path"].as_str();
+    let group = arguments["group"].as_str();
+
+    if instance_path.is_none() && group.is_none() {
+        return mcp_error_result(id, "Either 'instance_path' or 'group' parameter is required");
+    }
+
+    let body = if let Some(path) = instance_path {
+        json!({ "path": path })
+    } else {
+        json!({ "group": group.unwrap() })
     };
 
-    let code = format!(
-        r#"
-local inst = {}
-if inst then
-    if _G._roxlit_telemetry then
-        _G._roxlit_telemetry:untrack(inst)
-        print("[Telemetry] Stopped tracking " .. inst:GetFullName())
-    else
-        warn("[Telemetry] Telemetry module not running")
-    end
-else
-    warn("[Telemetry] Instance not found: {}")
-end
-"#,
-        instance_path, instance_path
-    );
+    let url = format!("{LAUNCHER_URL}/telemetry/untrack");
+    match http_post_json(&url, &body.to_string()) {
+        Ok(_) => {
+            let target = instance_path.unwrap_or_else(|| group.unwrap());
+            mcp_result(id, &format!("Stopped tracking: {target}"))
+        }
+        Err(e) => mcp_error_result(id, &format!("Failed to stop tracker: {e}")),
+    }
+}
 
-    let run_args = json!({ "code": code });
-    tool_run_code(id, &run_args)
+fn tool_telemetry_toggle(id: Value, arguments: &Value) -> Value {
+    let group = match arguments["group"].as_str() {
+        Some(g) => g,
+        None => return mcp_error_result(id, "'group' parameter is required"),
+    };
+    let enabled = arguments["enabled"].as_bool().unwrap_or(true);
+
+    let body = json!({ "group": group, "enabled": enabled });
+    let url = format!("{LAUNCHER_URL}/telemetry/toggle");
+    match http_post_json(&url, &body.to_string()) {
+        Ok(_) => {
+            let state = if enabled { "enabled" } else { "disabled" };
+            mcp_result(id, &format!("Group '{}' {}", group, state))
+        }
+        Err(e) => mcp_error_result(id, &format!("Failed to toggle group: {e}")),
+    }
 }
 
 fn tool_telemetry_get(id: Value, arguments: &Value) -> Value {

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -598,6 +598,40 @@ async fn handle_connection(
         return;
     }
 
+    // POST /telemetry — receives telemetry data from Studio plugin
+    if first_line.starts_with("POST /telemetry") {
+        if let Some(body_start) = request.find("\r\n\r\n") {
+            let body = &request[body_start + 4..];
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(body) {
+                if let Some(lines) = val["lines"].as_str() {
+                    // Write to telemetry.log in the project's .roxlit/logs/ dir
+                    let guard = status.lock().await;
+                    if !guard.project_path.is_empty() {
+                        let logs_dir = std::path::Path::new(&guard.project_path)
+                            .join(".roxlit")
+                            .join("logs");
+                        drop(guard); // Release lock before file I/O
+                        let _ = tokio::fs::create_dir_all(&logs_dir).await;
+                        let telemetry_file = logs_dir.join("telemetry.log");
+                        if let Ok(mut f) = tokio::fs::OpenOptions::new()
+                            .create(true)
+                            .append(true)
+                            .open(&telemetry_file)
+                            .await
+                        {
+                            use tokio::io::AsyncWriteExt;
+                            let _ = f.write_all(lines.as_bytes()).await;
+                            let _ = f.write_all(b"\n").await;
+                        }
+                    }
+                }
+            }
+        }
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\nok";
+        let _ = stream.write_all(response.as_bytes()).await;
+        return;
+    }
+
     // ─── MCP endpoints ────────────────────────────────────────────────────
 
     // POST /mcp/run-code — MCP sends Luau code, blocks until plugin returns result

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -162,6 +162,10 @@ impl SessionLogger {
             let rotated = logs_dir.join(format!("{ts}-output.log"));
             let _ = tokio::fs::rename(&output_file, &rotated).await;
         }
+        let telemetry_file = logs_dir.join("telemetry.log");
+        if telemetry_file.exists() {
+            let _ = tokio::fs::remove_file(&telemetry_file).await;
+        }
         // Also rotate legacy latest.log if present
         let latest = logs_dir.join("latest.log");
         if latest.exists() {

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -107,6 +107,46 @@ impl McpState {
     }
 }
 
+// ─── Telemetry Tracker Registry ──────────────────────────────────────────────
+// AI registers trackers via MCP → launcher HTTP. Plugin polls for the list.
+// Trackers are path-based (resolved lazily by the plugin during Heartbeat).
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub(crate) struct TelemetryTracker {
+    pub path: String,       // e.g. "Workspace.motorcycle_1_V2 Motorcycle.DriveSeat"
+    pub properties: String, // e.g. "CFrame,AssemblyLinearVelocity"
+    #[serde(default)]
+    pub group: String,      // e.g. "moto-body"
+    #[serde(default = "default_enabled")]
+    pub enabled: bool,
+}
+
+fn default_enabled() -> bool { true }
+
+pub struct TelemetryState {
+    inner: Arc<Mutex<TelemetryStateInner>>,
+}
+
+pub(crate) struct TelemetryStateInner {
+    pub(crate) trackers: Vec<TelemetryTracker>,
+}
+
+impl Default for TelemetryState {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TelemetryStateInner {
+                trackers: Vec::new(),
+            })),
+        }
+    }
+}
+
+impl TelemetryState {
+    pub fn shared(&self) -> Arc<Mutex<TelemetryStateInner>> {
+        self.inner.clone()
+    }
+}
+
 // ─── Logger State ────────────────────────────────────────────────────────────
 
 /// Managed Tauri state holding the current session logger (if any).
@@ -444,6 +484,7 @@ pub async fn start_log_server(
     output_tx: mpsc::UnboundedSender<String>,
     status: Arc<Mutex<LauncherStatusInner>>,
     mcp: Arc<Mutex<McpStateInner>>,
+    telemetry: Arc<Mutex<TelemetryStateInner>>,
 ) -> Option<tokio::task::JoinHandle<()>> {
     let listener = TcpListener::bind("127.0.0.1:19556").await.ok()?;
 
@@ -458,8 +499,9 @@ pub async fn start_log_server(
             let out_tx = output_tx.clone();
             let status = status.clone();
             let mcp = mcp.clone();
+            let telemetry = telemetry.clone();
             tokio::spawn(async move {
-                handle_connection(stream, sys_tx, out_tx, status, mcp).await;
+                handle_connection(stream, sys_tx, out_tx, status, mcp, telemetry).await;
             });
         }
     });
@@ -474,6 +516,7 @@ async fn handle_connection(
     output_tx: mpsc::UnboundedSender<String>,
     status: Arc<Mutex<LauncherStatusInner>>,
     mcp: Arc<Mutex<McpStateInner>>,
+    telemetry: Arc<Mutex<TelemetryStateInner>>,
 ) {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -596,6 +639,80 @@ async fn handle_connection(
         if let Some(body_start) = request.find("\r\n\r\n") {
             let body = &request[body_start + 4..];
             process_log_batch(&output_tx, body);
+        }
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\nok";
+        let _ = stream.write_all(response.as_bytes()).await;
+        return;
+    }
+
+    // GET /telemetry/trackers — plugin polls for tracker definitions
+    if first_line.starts_with("GET /telemetry/trackers") {
+        let guard = telemetry.lock().await;
+        let json = serde_json::to_string(&guard.trackers).unwrap_or_else(|_| "[]".to_string());
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\n{}",
+            json.len(), json,
+        );
+        let _ = stream.write_all(response.as_bytes()).await;
+        return;
+    }
+
+    // POST /telemetry/track — MCP registers a tracker
+    if first_line.starts_with("POST /telemetry/track") {
+        if let Some(body_start) = request.find("\r\n\r\n") {
+            let body = &request[body_start + 4..];
+            if let Ok(tracker) = serde_json::from_str::<TelemetryTracker>(body) {
+                let mut guard = telemetry.lock().await;
+                // Remove existing tracker with same path
+                guard.trackers.retain(|t| t.path != tracker.path);
+                let msg = format!("Telemetry: tracking {} ({})", tracker.path, tracker.properties);
+                guard.trackers.push(tracker);
+                drop(guard);
+                send_log(&system_tx, "telemetry", &msg);
+            }
+        }
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\nok";
+        let _ = stream.write_all(response.as_bytes()).await;
+        return;
+    }
+
+    // POST /telemetry/untrack — MCP removes a tracker
+    if first_line.starts_with("POST /telemetry/untrack") {
+        if let Some(body_start) = request.find("\r\n\r\n") {
+            let body = &request[body_start + 4..];
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(body) {
+                let mut guard = telemetry.lock().await;
+                if let Some(path) = val["path"].as_str() {
+                    guard.trackers.retain(|t| t.path != path);
+                    send_log(&system_tx, "telemetry", &format!("Telemetry: stopped tracking {path}"));
+                } else if let Some(group) = val["group"].as_str() {
+                    guard.trackers.retain(|t| t.group != group);
+                    send_log(&system_tx, "telemetry", &format!("Telemetry: stopped group {group}"));
+                }
+            }
+        }
+        let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\nok";
+        let _ = stream.write_all(response.as_bytes()).await;
+        return;
+    }
+
+    // POST /telemetry/toggle — enable/disable a group
+    if first_line.starts_with("POST /telemetry/toggle") {
+        if let Some(body_start) = request.find("\r\n\r\n") {
+            let body = &request[body_start + 4..];
+            if let Ok(val) = serde_json::from_str::<serde_json::Value>(body) {
+                if let Some(group) = val["group"].as_str() {
+                    let enabled = val["enabled"].as_bool().unwrap_or(true);
+                    let mut guard = telemetry.lock().await;
+                    for t in guard.trackers.iter_mut() {
+                        if t.group == group {
+                            t.enabled = enabled;
+                        }
+                    }
+                    let state = if enabled { "enabled" } else { "disabled" };
+                    send_log(&system_tx, "telemetry", &format!("Telemetry: {state} group {group}"));
+                }
+            }
         }
         let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\nok";
         let _ = stream.write_all(response.as_bytes()).await;

--- a/src-tauri/src/commands/logs.rs
+++ b/src-tauri/src/commands/logs.rs
@@ -129,6 +129,7 @@ pub struct TelemetryState {
 
 pub(crate) struct TelemetryStateInner {
     pub(crate) trackers: Vec<TelemetryTracker>,
+    pub(crate) project_path: String,
 }
 
 impl Default for TelemetryState {
@@ -136,6 +137,7 @@ impl Default for TelemetryState {
         Self {
             inner: Arc::new(Mutex::new(TelemetryStateInner {
                 trackers: Vec::new(),
+                project_path: String::new(),
             })),
         }
     }
@@ -144,6 +146,30 @@ impl Default for TelemetryState {
 impl TelemetryState {
     pub fn shared(&self) -> Arc<Mutex<TelemetryStateInner>> {
         self.inner.clone()
+    }
+}
+
+fn trackers_file(project_path: &str) -> std::path::PathBuf {
+    std::path::Path::new(project_path).join(".roxlit").join("telemetry-trackers.json")
+}
+
+async fn save_trackers(trackers: &[TelemetryTracker], project_path: &str) {
+    if project_path.is_empty() { return; }
+    let path = trackers_file(project_path);
+    if let Some(parent) = path.parent() {
+        let _ = tokio::fs::create_dir_all(parent).await;
+    }
+    if let Ok(json) = serde_json::to_string_pretty(trackers) {
+        let _ = tokio::fs::write(&path, json).await;
+    }
+}
+
+pub(crate) async fn load_trackers(project_path: &str) -> Vec<TelemetryTracker> {
+    if project_path.is_empty() { return Vec::new(); }
+    let path = trackers_file(project_path);
+    match tokio::fs::read_to_string(&path).await {
+        Ok(json) => serde_json::from_str(&json).unwrap_or_default(),
+        Err(_) => Vec::new(),
     }
 }
 
@@ -667,7 +693,10 @@ async fn handle_connection(
                 guard.trackers.retain(|t| t.path != tracker.path);
                 let msg = format!("Telemetry: tracking {} ({})", tracker.path, tracker.properties);
                 guard.trackers.push(tracker);
+                let trackers_clone = guard.trackers.clone();
+                let pp = guard.project_path.clone();
                 drop(guard);
+                save_trackers(&trackers_clone, &pp).await;
                 send_log(&system_tx, "telemetry", &msg);
             }
         }
@@ -689,6 +718,10 @@ async fn handle_connection(
                     guard.trackers.retain(|t| t.group != group);
                     send_log(&system_tx, "telemetry", &format!("Telemetry: stopped group {group}"));
                 }
+                let trackers_clone = guard.trackers.clone();
+                let pp = guard.project_path.clone();
+                drop(guard);
+                save_trackers(&trackers_clone, &pp).await;
             }
         }
         let response = "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\nAccess-Control-Allow-Origin: *\r\n\r\nok";
@@ -710,6 +743,10 @@ async fn handle_connection(
                         }
                     }
                     let state = if enabled { "enabled" } else { "disabled" };
+                    let trackers_clone = guard.trackers.clone();
+                    let pp = guard.project_path.clone();
+                    drop(guard);
+                    save_trackers(&trackers_clone, &pp).await;
                     send_log(&system_tx, "telemetry", &format!("Telemetry: {state} group {group}"));
                 }
             }

--- a/src-tauri/src/commands/rojo.rs
+++ b/src-tauri/src/commands/rojo.rs
@@ -90,6 +90,7 @@ pub async fn start_rojo(
     log_server_state: tauri::State<'_, LogServerState>,
     launcher_status: tauri::State<'_, LauncherStatus>,
     mcp_state: tauri::State<'_, crate::commands::logs::McpState>,
+    telemetry_state: tauri::State<'_, crate::commands::logs::TelemetryState>,
 ) -> Result<()> {
     // Check if already running
     {
@@ -222,7 +223,8 @@ pub async fn start_rojo(
     if let (Some(ref sys_tx), Some(ref out_tx)) = (&system_sender, &output_sender) {
         let shared_status = launcher_status.shared();
         let shared_mcp = mcp_state.shared();
-        if let Some(handle) = crate::commands::logs::start_log_server(sys_tx.clone(), out_tx.clone(), shared_status, shared_mcp).await {
+        let shared_telemetry = telemetry_state.shared();
+        if let Some(handle) = crate::commands::logs::start_log_server(sys_tx.clone(), out_tx.clone(), shared_status, shared_mcp, shared_telemetry).await {
             log_server_state.set_handle(handle).await;
             send_log(sys_tx, "roxlit", "Studio log server started on 127.0.0.1:19556");
         }

--- a/src-tauri/src/commands/rojo.rs
+++ b/src-tauri/src/commands/rojo.rs
@@ -224,6 +224,21 @@ pub async fn start_rojo(
         let shared_status = launcher_status.shared();
         let shared_mcp = mcp_state.shared();
         let shared_telemetry = telemetry_state.shared();
+        // Load persisted telemetry trackers
+        {
+            let saved = crate::commands::logs::load_trackers(&project_path).await;
+            if !saved.is_empty() {
+                let mut tg = shared_telemetry.lock().await;
+                tg.trackers = saved;
+                tg.project_path = project_path.clone();
+                let count = tg.trackers.len();
+                drop(tg);
+                send_log(sys_tx, "telemetry", &format!("Loaded {count} saved trackers"));
+            } else {
+                let mut tg = shared_telemetry.lock().await;
+                tg.project_path = project_path.clone();
+            }
+        }
         if let Some(handle) = crate::commands::logs::start_log_server(sys_tx.clone(), out_tx.clone(), shared_status, shared_mcp, shared_telemetry).await {
             log_server_state.set_handle(handle).await;
             send_log(sys_tx, "roxlit", "Studio log server started on 127.0.0.1:19556");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -95,6 +95,7 @@ pub fn run() {
         .manage(commands::logs::LogServerState::default())
         .manage(commands::logs::LauncherStatus::default())
         .manage(commands::logs::McpState::default())
+        .manage(commands::logs::TelemetryState::default())
         .invoke_handler(tauri::generate_handler![
             commands::detect::detect_environment,
             commands::install::run_installation,

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -190,7 +190,7 @@ MCP tools connect to Roblox Studio via the Roxlit plugin. Use them ONLY for:
 - `backup_list` — List all backups with IDs, names, and timestamps.
 - `backup_restore` — Revert all files to a backup state. Automatically saves current state first (so you can undo).
 - `backup_diff` — Show what changed since a backup was created.
-- `telemetry_track` — Start tracking properties of an instance in real-time. Pass instance path and comma-separated property names. Uses `_roxlit_track` attribute under the hood.
+- `telemetry_track` — Start tracking properties of an instance in real-time. Pass instance path and comma-separated property names. Registers directly with the plugin's telemetry module.
 - `telemetry_stop` — Stop tracking an instance. Removes the `_roxlit_track` attribute.
 - `telemetry_get` — Read telemetry data. Supports `instance_name` filter and `tail` parameter. Returns timestamped property snapshots.
 - `telemetry_clear` — Clear the telemetry log file.

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -431,6 +431,78 @@ The filename (minus `.model.json`) becomes the instance Name. Rojo places it und
 - To delete an instance from Studio, delete the .model.json file
 - .model.json files are versionable in git and diffable — this is a huge advantage over MCP-based creation
 
+## Creating Animations via run_code
+
+You can create animations programmatically using `run_code`. This is useful for character animations (walk, idle, attack, get-up, etc.) without needing the Animation Editor in Studio.
+
+### How it works
+
+1. **Create a KeyframeSequence** with Keyframes, each containing Poses for joints
+2. **Register it** with KeyframeSequenceProvider to get an animation asset ID
+3. **Play it** via Animator:LoadAnimation()
+
+### Example — simple wave animation
+
+```lua
+run_code([[
+local KFS = Instance.new("KeyframeSequence")
+KFS.Name = "Wave"
+KFS.Loop = false
+
+-- Keyframe at t=0: arm down (neutral)
+local kf0 = Instance.new("Keyframe")
+kf0.Time = 0
+local rootPose = Instance.new("Pose")
+rootPose.Name = "HumanoidRootPart"
+-- Right shoulder pose
+local rShoulder = Instance.new("Pose")
+rShoulder.Name = "Right Shoulder"
+rShoulder.CFrame = CFrame.Angles(0, 0, 0)
+rootPose:AddSubPose(rShoulder)
+kf0:AddPose(rootPose)
+KFS:AddKeyframe(kf0)
+
+-- Keyframe at t=0.5: arm up
+local kf1 = Instance.new("Keyframe")
+kf1.Time = 0.5
+local rootPose1 = Instance.new("Pose")
+rootPose1.Name = "HumanoidRootPart"
+local rShoulder1 = Instance.new("Pose")
+rShoulder1.Name = "Right Shoulder"
+rShoulder1.CFrame = CFrame.Angles(0, 0, math.rad(-150))
+rootPose1:AddSubPose(rShoulder1)
+kf1:AddPose(rootPose1)
+KFS:AddKeyframe(kf1)
+
+-- Register and get asset ID
+local KSP = game:GetService("KeyframeSequenceProvider")
+local assetId = KSP:RegisterKeyframeSequenceAsync(KFS)
+print("Animation registered:", assetId)
+]])
+```
+
+### Joint names (R15 rig)
+
+Use these as Pose names — they match Motor6D names in the character:
+- `Root Hip` — torso to root
+- `Left Hip`, `Right Hip` — legs
+- `Left Shoulder`, `Right Shoulder` — arms
+- `Left Knee`, `Right Knee` — lower legs
+- `Left Ankle`, `Right Ankle` — feet
+- `Left Elbow`, `Right Elbow` — forearms
+- `Left Wrist`, `Right Wrist` — hands
+- `Neck` — head
+- `Waist` — upper/lower torso
+
+### Tips
+
+- **Iterate**: Create the animation, play it, adjust CFrame angles, repeat. Ask the user if it looks right.
+- **Small angle changes**: When refining, change angles by at least 5-10 degrees per iteration — smaller changes are invisible.
+- **Log what you changed**: Always tell the user what angles you modified and why.
+- **CFrame.Angles uses radians**: Use `math.rad(degrees)` for readability.
+- **Easing**: Set `kf.EasingStyle` and `kf.EasingDirection` on Keyframes for smooth transitions.
+- **Priority**: Set `AnimationTrack.Priority` to `Enum.AnimationPriority.Action` for one-shot animations that override idle/walk.
+
 "#;
 
     format!(

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -190,14 +190,17 @@ MCP tools connect to Roblox Studio via the Roxlit plugin. Use them ONLY for:
 - `backup_list` — List all backups with IDs, names, and timestamps.
 - `backup_restore` — Revert all files to a backup state. Automatically saves current state first (so you can undo).
 - `backup_diff` — Show what changed since a backup was created.
-- `telemetry_track` — Start tracking properties of an instance in real-time. Pass instance path and comma-separated property names. Registers directly with the plugin's telemetry module.
-- `telemetry_stop` — Stop tracking an instance. Removes the `_roxlit_track` attribute.
-- `telemetry_get` — Read telemetry data. Supports `instance_name` filter and `tail` parameter. Returns timestamped property snapshots.
+- `telemetry_track` — Register an instance for real-time property tracking. Pass path, properties, and optional group. The instance does NOT need to exist — tracking activates automatically when it appears (e.g. during playtest). Names with spaces work.
+- `telemetry_stop` — Stop tracking. Pass `instance_path` for one tracker, or `group` to stop all in a group.
+- `telemetry_toggle` — Enable/disable a group without removing it (e.g. pause noisy trackers temporarily).
+- `telemetry_get` — Read telemetry data. Supports `instance` filter and `tail` parameter.
 - `telemetry_clear` — Clear the telemetry log file.
 
 ### Real-Time Telemetry
 
 Use telemetry to observe how instances behave during playtests WITHOUT pausing or adding print statements.
+
+**Key feature:** Trackers are **deferred** — register them anytime, they activate when the instance exists. Perfect for instances that only appear during playtest (spawned vehicles, player characters, etc.).
 
 **When to use:**
 - Debugging physics (track CFrame, AssemblyLinearVelocity, AssemblyAngularVelocity)
@@ -206,21 +209,26 @@ Use telemetry to observe how instances behave during playtests WITHOUT pausing o
 - Tuning gameplay (track Health, Speed, or custom attributes)
 
 **Workflow:**
-1. `telemetry_track` on the instance(s) you care about
-2. Ask user to playtest or interact
-3. `telemetry_get` to see the data (filter by instance name if needed)
-4. `telemetry_stop` when done
+1. `telemetry_track` — register trackers (works even before playtest)
+2. User starts playtest → trackers activate automatically
+3. `telemetry_get` to see the data
+4. `telemetry_stop` or `telemetry_toggle` when done
 
-**Example — debug a vehicle:**
+**Example — debug a vehicle with groups:**
 ```
-telemetry_track(instance_path: "Workspace.MyCar.Chassis", properties: "CFrame,AssemblyLinearVelocity")
--- User drives the car --
-telemetry_get(instance_name: "Chassis", tail: 20)
--- See position/velocity over time --
-telemetry_stop(instance_path: "Workspace.MyCar.Chassis")
+telemetry_track(instance_path: "Workspace.motorcycle_1_V2 Motorcycle.DriveSeat", properties: "CFrame,AssemblyLinearVelocity", group: "moto-body")
+telemetry_track(instance_path: "Workspace.motorcycle_1_V2 Motorcycle.WheelFront", properties: "CFrame,AssemblyAngularVelocity", group: "moto-wheels")
+telemetry_track(instance_path: "Workspace.motorcycle_1_V2 Motorcycle.WheelRear", properties: "CFrame,AssemblyAngularVelocity", group: "moto-wheels")
+-- User playtests and drives --
+telemetry_get(tail: 30)
+-- Too much data? Disable wheels, keep body --
+telemetry_toggle(group: "moto-wheels", enabled: false)
+-- Done debugging --
+telemetry_stop(group: "moto-body")
+telemetry_stop(group: "moto-wheels")
 ```
 
-**Format:** Each line is `[T+seconds] [CLIENT/SERVER] InstanceName Property: value | Property: value`
+**Format:** Each line is `[T+seconds] [CLIENT/SERVER] [group] InstanceName Property: value | Property: value`
 Only significant changes are logged (position > 0.1 studs, angle > 0.5 degrees, scalar > 0.01).
 
 **Do NOT use MCP to create instances.** Write .model.json files instead — Rojo syncs them automatically.

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -592,7 +592,11 @@ src/                                ← All game code and instances (synced by R
 - Require modules relatively: `require(script.Parent.ModuleName)`
 - Prefer `task.wait()` over `wait()`, `task.spawn()` over `spawn()`
 - Add `--!strict` at the top of every file
-- In `string.gsub()` replacements, `%` is a special character. Escape it as `%%` or use a function replacement: `gsub(pattern, function() return str end)`
+- **CRITICAL `string.gsub` rule:** The replacement string treats `%` as special. Code like `gsub(pat, newStr)` where `newStr` contains `%` (e.g. `string.format("%.1f", x)`) will ERROR with "invalid use of '%'". **ALWAYS use the function form for literal replacement:**
+  ```lua
+  src:gsub(pattern, function() return newString end)
+  ```
+  This applies to ANY gsub where the replacement might contain `%`, `string.format`, format specifiers, or Lua patterns. Never use the string form unless you are 100% certain the replacement has no `%`.
 
 ## Instance Organization
 

--- a/src-tauri/src/templates/mod.rs
+++ b/src-tauri/src/templates/mod.rs
@@ -162,7 +162,7 @@ pub fn roxlit_mcp_json(project_name: &str) -> String {
 /// Context version — bump this whenever ai_context() content changes significantly.
 /// ensure_ai_context() compares this against the marker in the existing file to decide
 /// whether to regenerate. Format: same as Cargo.toml version.
-pub const CONTEXT_VERSION: &str = "0.11.0";
+pub const CONTEXT_VERSION: &str = "0.12.0";
 
 /// Marker prefix used to embed the version in the generated context file.
 /// Must be a comment that AI tools will ignore but we can parse.
@@ -190,6 +190,38 @@ MCP tools connect to Roblox Studio via the Roxlit plugin. Use them ONLY for:
 - `backup_list` — List all backups with IDs, names, and timestamps.
 - `backup_restore` — Revert all files to a backup state. Automatically saves current state first (so you can undo).
 - `backup_diff` — Show what changed since a backup was created.
+- `telemetry_track` — Start tracking properties of an instance in real-time. Pass instance path and comma-separated property names. Uses `_roxlit_track` attribute under the hood.
+- `telemetry_stop` — Stop tracking an instance. Removes the `_roxlit_track` attribute.
+- `telemetry_get` — Read telemetry data. Supports `instance_name` filter and `tail` parameter. Returns timestamped property snapshots.
+- `telemetry_clear` — Clear the telemetry log file.
+
+### Real-Time Telemetry
+
+Use telemetry to observe how instances behave during playtests WITHOUT pausing or adding print statements.
+
+**When to use:**
+- Debugging physics (track CFrame, AssemblyLinearVelocity, AssemblyAngularVelocity)
+- Monitoring animations (track CFrame of joints/parts)
+- Verifying UI updates (track Position, Size, Text of GUI elements)
+- Tuning gameplay (track Health, Speed, or custom attributes)
+
+**Workflow:**
+1. `telemetry_track` on the instance(s) you care about
+2. Ask user to playtest or interact
+3. `telemetry_get` to see the data (filter by instance name if needed)
+4. `telemetry_stop` when done
+
+**Example — debug a vehicle:**
+```
+telemetry_track(instance_path: "Workspace.MyCar.Chassis", properties: "CFrame,AssemblyLinearVelocity")
+-- User drives the car --
+telemetry_get(instance_name: "Chassis", tail: 20)
+-- See position/velocity over time --
+telemetry_stop(instance_path: "Workspace.MyCar.Chassis")
+```
+
+**Format:** Each line is `[T+seconds] [CLIENT/SERVER] InstanceName Property: value | Property: value`
+Only significant changes are logged (position > 0.1 studs, angle > 0.5 degrees, scalar > 0.01).
 
 **Do NOT use MCP to create instances.** Write .model.json files instead — Rojo syncs them automatically.
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Roxlit",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "identifier": "dev.roxlit.app",
   "build": {
     "frontendDist": "../dist",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-config-schema/schema.json",
   "productName": "Roxlit",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "identifier": "dev.roxlit.app",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
## Summary

- **Real-time telemetry**: Track instance properties (CFrame, velocity, etc.) during playtests without print statements
- **Deferred trackers**: Register trackers anytime — they activate automatically when instances appear (e.g. spawned vehicles)
- **Groups**: Organize trackers by group, enable/disable groups without removing them
- **Names with spaces**: FindFirstChild-based path resolution supports any instance name
- **Persistent trackers**: Saved to `.roxlit/telemetry-trackers.json`, survive launcher restarts
- **Plugin polls launcher**: No more run_code dependency or DataModel scanning
- **`_replace()` in run_code**: Safe literal string replacement, prevents gsub % corruption
- **Auto-backups**: Every 10min while development active, size-based cleanup (100MB limit)
- **AI context v0.12.0**: Telemetry docs, animation creation, strengthened gsub warning, backup discipline

## New MCP tools

- `telemetry_track(instance_path, properties, group)` — register a tracker
- `telemetry_stop(instance_path | group)` — remove trackers
- `telemetry_toggle(group, enabled)` — enable/disable group
- `telemetry_get(project_path, tail, instance)` — read telemetry data
- `telemetry_clear(project_path)` — clear telemetry log

## Architecture

```
MCP → POST /telemetry/track → Launcher (stores in memory + disk)
Plugin → GET /telemetry/trackers (polls every 3s) → resolves paths with FindFirstChild
Plugin → Heartbeat samples → POST /telemetry → Launcher writes telemetry.log
MCP → reads telemetry.log
```

## Test plan

- [x] Register trackers before playtest, verify they activate when instances spawn
- [x] Names with spaces work (e.g. "motorcycle_1_V2 Motorcycle")
- [x] Trackers persist across launcher restart
- [x] Groups enable/disable correctly
- [x] Telemetry data shows in telemetry_get with correct format
- [x] telemetry.log cleared at session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)