### PR TITLE
chore: enable Dependabot (npm, cargo, github-actions)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+updates:
+  # Frontend dependencies (React + TypeScript). npm prod and dev are grouped
+  # separately so production changes get their own reviewable PR.
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+    groups:
+      npm-production:
+        dependency-type: production
+      npm-development:
+        dependency-type: development
+
+  # Rust dependencies (Tauri backend). Group patch+minor (safe to batch);
+  # majors land as individual PRs so each breaking bump is reviewed alone.
+  - package-ecosystem: cargo
+    directory: "/src-tauri"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"
+    groups:
+      cargo-safe:
+        update-types:
+          - minor
+          - patch
+
+  # Keep workflow actions (checkout, setup-node, tauri-action, etc.) current.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore"


### PR DESCRIPTION
## What

Adds `.github/dependabot.yml` so Dependabot generates weekly update PRs for the three ecosystems in use: **npm** (frontend), **cargo** (`src-tauri`), and **github-actions** (workflows).

## Why

The repo has 18 open Dependabot alerts but no `dependabot.yml`, so nothing was turning them into actionable PRs. This converts static alerts into reviewable updates going forward.

Scoping notes from the audit behind this:
- The 8 npm alerts are all in `devDependencies` (vite, postcss, babel, picomatch) — `npm audit --omit=dev` reports 0 in production.
- The 10 cargo alerts need `cargo update --precise` per crate (a bare `cargo update` pulls 0.x majors like cssparser/ctor/derive_more that break the build). Those are deferred to individual Dependabot PRs now that this config exists.
- `Roxlit/rojo`'s 21 alerts are left out on purpose: that fork only ships the Lua plugin; its Rust binary isn't published to users (Aftman installs Rojo upstream), so those alerts are noise.

## Config choices

- Weekly cadence (not daily) to keep noise low.
- `open-pull-requests-limit: 5` per ecosystem.
- cargo: group `patch`+`minor` (safe to batch); majors stay individual PRs.
- npm: split production vs development dependencies.

## How to test

After merge, Dependabot opens its first batch of PRs within ~24-72h. Verify they target `dev` and that a cargo PR builds green in CI before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)